### PR TITLE
Fix dependency issue with github.com/sagikazarmark/utilz

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,3 +97,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+// Fix for invalid syntax in go.mod at old revision
+replace github.com/sagikazarmark/utilz v0.0.0-20180515183603-c488e427c90e => github.com/sagikazarmark/utilz v0.0.0-20191016080303-3ffcdad78fca


### PR DESCRIPTION
## Fix dependency issue with github.com/sagikazarmark/utilz

### Problem
The build was failing with this error:
```
go: github.com/sagikazarmark/utilz@v0.0.0-20180515183603-c488e427c90e: reading github.com/sagikazarmark/utilz/go.mod at revision c488e427c90e: invalid: invalid syntax in go.mod
```

### Solution
Added a replace directive in go.mod to use a newer version of the utilz package that has proper Go modules support.

The root cause was that the old version of the dependency predates proper Go modules support, and its go.mod file had invalid syntax. By replacing it with a newer version that has proper Go modules support, we can fix the build.

This change was successfully tested with a complete build of the application using `GOFLAGS=-mod=readonly go build ./...`