### PR TITLE
Fix syntax errors in config.go and event_handlers.go

### DIFF
--- a/cmd/modern-go-application/config.go
+++ b/cmd/modern-go-application/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"errors"
-	"os
+	"os"
 	"strings"
-	"stringss"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -30,7 +29,7 @@ type configuration struct {
 	// OpenCensus configuration
 	Opencensus struct {
 		Exporter struct {
-			Enabled
+			Enabled bool
 
 			opencensus.ExporterConfig `mapstructure:",squash"`
 		}

--- a/internal/app/mga/todo/event_handlers.go
+++ b/internal/app/mga/todo/event_handlers.go
@@ -10,7 +10,7 @@ type LogEventHandler struct {
 }
 
 // NewLogEventHandler returns a new LogEventHandler instance.
-NewLogEventHandler(logger Logger) LogEventHandler {
+func NewLogEventHandler(logger Logger) LogEventHandler {
 	return LogEventHandler{
 		logger: logger,
 	}


### PR DESCRIPTION
This PR fixes several syntax errors in the codebase that were preventing the application from building successfully:

1. In `cmd/modern-go-application/config.go`:
   - Added the missing closing quotation mark in the import statement for the "os" package
   - Removed a non-existent import for "stringss"
   - Added the required boolean type to the `Enabled` field in the Opencensus struct

2. In `internal/app/mga/todo/event_handlers.go`:
   - Added the missing `func` keyword to the `NewLogEventHandler` function declaration

These changes allow the code to compile and the application to build successfully.