### PR TITLE
Fix import errors in config.go

### DIFF
--- a/cmd/modern-go-application/config.go
+++ b/cmd/modern-go-application/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"errors"
-	"os
+	"os"
 	"strings"
-	"stringss"
 	"time"
 
 	"github.com/spf13/pflag"


### PR DESCRIPTION
This PR fixes the following issues in the config.go file:

1. Adds the missing closing quotation mark for the "os" import
2. Removes the non-existent "stringss" import package which is a typo and unnecessary since "strings" is already imported

The error that occurred during the build process was:
```
cmd/modern-go-application/config.go:5:2: string literal not terminated
```

This was preventing the application from building successfully. The fix should resolve the build failure.