### PR TITLE
Fix syntax errors in config.go import statements

### DIFF
--- a/cmd/modern-go-application/config.go
+++ b/cmd/modern-go-application/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"errors"
-	"os
+	"os"
 	"strings"
-	"stringss"
 	"time"
 
 	"github.com/spf13/pflag"


### PR DESCRIPTION
## Fix for build failure

This PR fixes the build failure in `cmd/modern-go-application/config.go`.

### Changes:
1. Added missing closing quote to "os" import statement
2. Removed invalid "stringss" import which is not a standard Go package

These syntax errors were causing the build to fail with the error:
```
cmd/modern-go-application/config.go:5:2: string literal not terminated
```

This PR resolves the issue by properly formatting the import statements.