### PR TITLE
Fix syntax errors blocking build

### DIFF
--- a/cmd/modern-go-application/config.go
+++ b/cmd/modern-go-application/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"errors"
-	"os
+	"os"
 	"strings"
-	"stringss"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -30,7 +29,7 @@ type configuration struct {
 	// OpenCensus configuration
 	Opencensus struct {
 		Exporter struct {
-			Enabled
+			Enabled bool
 
 			opencensus.ExporterConfig `mapstructure:",squash"`
 		}

--- a/internal/app/mga/todo/event_handlers.go
+++ b/internal/app/mga/todo/event_handlers.go
@@ -10,7 +10,7 @@ type LogEventHandler struct {
 }
 
 // NewLogEventHandler returns a new LogEventHandler instance.
-NewLogEventHandler(logger Logger) LogEventHandler {
+func NewLogEventHandler(logger Logger) LogEventHandler {
 	return LogEventHandler{
 		logger: logger,
 	}


### PR DESCRIPTION
## Description

This PR fixes multiple syntax errors that were causing the build to fail:

1. Fixed unterminated string literal in import of "os" (added missing closing quote)
2. Removed invalid/duplicate import of "stringss"
3. Added missing bool type to Enabled field in Opencensus Exporter struct
4. Added missing "func" keyword to the NewLogEventHandler function

These fixes address the build failures in the CI workflow.

## Testing

Verified that the code now compiles successfully.