### PR TITLE
Fix syntax errors in config.go

### DIFF
--- a/cmd/modern-go-application/config.go
+++ b/cmd/modern-go-application/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"errors"
-	"os
+	"os"
 	"strings"
-	"stringss"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -30,7 +29,7 @@ type configuration struct {
 	// OpenCensus configuration
 	Opencensus struct {
 		Exporter struct {
-			Enabled
+			Enabled bool
 
 			opencensus.ExporterConfig `mapstructure:",squash"`
 		}


### PR DESCRIPTION
This PR fixes three syntax errors in the `cmd/modern-go-application/config.go` file:

1. Added the missing closing quote to the "os" import
2. Removed the non-existent "stringss" import (the correct "strings" package is already imported)
3. Added the missing boolean type to the Enabled field in the Opencensus struct

These changes ensure the code will compile correctly.