### PR TITLE
Fix syntax errors in config.go and event_handlers.go

### DIFF
--- a/cmd/modern-go-application/config.go
+++ b/cmd/modern-go-application/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"errors"
-	"os
+	"os"
 	"strings"
-	"stringss"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -30,7 +29,7 @@ type configuration struct {
 	// OpenCensus configuration
 	Opencensus struct {
 		Exporter struct {
-			Enabled
+			Enabled bool
 
 			opencensus.ExporterConfig `mapstructure:",squash"`
 		}

--- a/internal/app/mga/todo/event_handlers.go
+++ b/internal/app/mga/todo/event_handlers.go
@@ -10,7 +10,7 @@ type LogEventHandler struct {
 }
 
 // NewLogEventHandler returns a new LogEventHandler instance.
-NewLogEventHandler(logger Logger) LogEventHandler {
+func NewLogEventHandler(logger Logger) LogEventHandler {
 	return LogEventHandler{
 		logger: logger,
 	}


### PR DESCRIPTION
This PR fixes several syntax errors in the codebase:

In `cmd/modern-go-application/config.go`:
1. Added the missing closing quote to the "os" import
2. Removed the non-existent "stringss" import (the correct "strings" package is already imported)
3. Added the missing boolean type to the Enabled field in the Opencensus struct

In `internal/app/mga/todo/event_handlers.go`:
1. Added the missing `func` keyword to the NewLogEventHandler function declaration

These changes ensure the code will compile correctly.