### PR TITLE
Fix syntax errors in Go files

### DIFF
--- a/cmd/modern-go-application/config.go
+++ b/cmd/modern-go-application/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"errors"
-	"os
+	"os"
 	"strings"
-	"stringss"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -30,7 +29,7 @@ type configuration struct {
 	// OpenCensus configuration
 	Opencensus struct {
 		Exporter struct {
-			Enabled
+			Enabled bool
 
 			opencensus.ExporterConfig `mapstructure:",squash"`
 		}

--- a/internal/app/mga/todo/event_handlers.go
+++ b/internal/app/mga/todo/event_handlers.go
@@ -10,7 +10,7 @@ type LogEventHandler struct {
 }
 
 // NewLogEventHandler returns a new LogEventHandler instance.
-NewLogEventHandler(logger Logger) LogEventHandler {
+func NewLogEventHandler(logger Logger) LogEventHandler {
 	return LogEventHandler{
 		logger: logger,
 	}


### PR DESCRIPTION
This PR fixes syntax errors that were causing the build to fail:

1. In `cmd/modern-go-application/config.go`:
   - Fixed unterminated string literal by adding the missing closing quote to `"os"`
   - Removed the non-existent package `"stringss"` from the imports
   - Added the missing `bool` type to the `Enabled` field in the OpenCensus configuration struct

2. In `internal/app/mga/todo/event_handlers.go`:
   - Added the missing `func` keyword to the `NewLogEventHandler` function declaration

These syntax errors prevented the Go compiler from successfully building the application.