### PR TITLE
Fix import statement syntax errors in config.go

### DIFF
--- a/cmd/modern-go-application/config.go
+++ b/cmd/modern-go-application/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"errors"
-	"os
+	"os"
 	"strings"
-	"stringss"
 	"time"
 
 	"github.com/spf13/pflag"


### PR DESCRIPTION
## Description
This PR fixes the following syntax errors in the config.go file:

1. Adds the missing closing double quote to the "os" import statement
2. Removes the invalid "stringss" import which appears to be a typo

These syntax errors were causing the build to fail with the error message:
```
cmd/modern-go-application/config.go:5:2: string literal not terminated
```

## Changes Made
- Added the closing double quote to the "os" import
- Removed the redundant "stringss" import which is not a valid Go standard library package

This fix will allow the CI build to complete successfully.