### PR TITLE
Fix syntax errors in Go files

### DIFF
--- a/cmd/modern-go-application/config.go
+++ b/cmd/modern-go-application/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"errors"
-	"os
+	"os"
 	"strings"
-	"stringss"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -30,7 +29,7 @@ type configuration struct {
 	// OpenCensus configuration
 	Opencensus struct {
 		Exporter struct {
-			Enabled
+			Enabled bool
 
 			opencensus.ExporterConfig `mapstructure:",squash"`
 		}

--- a/internal/app/mga/todo/event_handlers.go
+++ b/internal/app/mga/todo/event_handlers.go
@@ -10,7 +10,7 @@ type LogEventHandler struct {
 }
 
 // NewLogEventHandler returns a new LogEventHandler instance.
-NewLogEventHandler(logger Logger) LogEventHandler {
+func NewLogEventHandler(logger Logger) LogEventHandler {
 	return LogEventHandler{
 		logger: logger,
 	}


### PR DESCRIPTION
This PR fixes multiple syntax errors in Go files:

1. Fixed unterminated string literal in `cmd/modern-go-application/config.go` import statement
2. Removed non-existent "stringss" package import
3. Added missing `func` keyword in `NewLogEventHandler` function in `internal/app/mga/todo/event_handlers.go`
4. Added missing type `bool` for `Enabled` field in `config.go`

These changes allow the application to build successfully.